### PR TITLE
feat(entity): 添加预算科目类型实体类

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,10 +34,6 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-security</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-cache</artifactId>
         </dependency>
         <dependency>

--- a/src/main/java/org/psd/budget_management/BudgetManagementApplication.java
+++ b/src/main/java/org/psd/budget_management/BudgetManagementApplication.java
@@ -5,6 +5,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 /**
  * @author pengshidun
+ * @since 2024-11-11
  */
 @SpringBootApplication
 public class BudgetManagementApplication {

--- a/src/main/java/org/psd/budget_management/entity/BudgetItemType.java
+++ b/src/main/java/org/psd/budget_management/entity/BudgetItemType.java
@@ -1,0 +1,55 @@
+package org.psd.budget_management.entity;
+
+import com.baomidou.mybatisplus.annotation.*;
+
+import java.io.Serializable;
+import java.time.LocalDateTime;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.Data;
+
+/**
+ * 预算科目类型
+ *
+ * @author pengshidun
+ * @TableName budget_item_type
+ * @since 2024-11-11
+ */
+@TableName(value = "budget_item_type")
+@Data
+public class BudgetItemType implements Serializable {
+    /**
+     * 预算科目类型id
+     */
+    @TableId(value = "id", type = IdType.AUTO)
+    private Integer id;
+
+    /**
+     * 预算科目类型名称
+     */
+    @TableField(value = "name")
+    private String name;
+
+    /**
+     * 创建时间
+     */
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    @TableField(value = "create_time", fill = FieldFill.INSERT)
+    private LocalDateTime createTime;
+
+    /**
+     * 更新时间
+     */
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    @TableField(value = "update_time", fill = FieldFill.INSERT_UPDATE)
+    private LocalDateTime updateTime;
+
+    /**
+     * 是否删除
+     */
+    @TableField(value = "is_deleted", fill = FieldFill.INSERT)
+    private Integer isDeleted;
+
+    @TableField(exist = false)
+    private static final long serialVersionUID = 1L;
+}

--- a/src/main/java/org/psd/budget_management/entity/Result.java
+++ b/src/main/java/org/psd/budget_management/entity/Result.java
@@ -1,0 +1,27 @@
+package org.psd.budget_management.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+/**
+ * @author pengshidun
+ * @since 2024-11-11
+ */
+@Data
+@AllArgsConstructor
+public class Result {
+    /**
+     * 状态码
+     */
+    private int code;
+
+    /**
+     * 消息
+     */
+    private String message;
+
+    /**
+     * 数据
+     */
+    private Object data;
+}

--- a/src/main/java/org/psd/budget_management/service/BudgetItemTypeService.java
+++ b/src/main/java/org/psd/budget_management/service/BudgetItemTypeService.java
@@ -1,0 +1,14 @@
+package org.psd.budget_management.service;
+
+import org.psd.budget_management.entity.BudgetItemType;
+import com.baomidou.mybatisplus.extension.service.IService;
+
+/**
+ * 针对表【budget_item_type(预算科目类型)】的数据库操作Service
+ *
+ * @author pengshidun
+ * @since 2024-11-11
+ */
+public interface BudgetItemTypeService extends IService<BudgetItemType> {
+
+}

--- a/src/main/java/org/psd/budget_management/service/impl/BudgetItemTypeServiceImpl.java
+++ b/src/main/java/org/psd/budget_management/service/impl/BudgetItemTypeServiceImpl.java
@@ -1,0 +1,18 @@
+package org.psd.budget_management.service.impl;
+
+import com.baomidou.mybatisplus.extension.service.impl.ServiceImpl;
+import org.psd.budget_management.entity.BudgetItemType;
+import org.psd.budget_management.service.BudgetItemTypeService;
+import org.psd.budget_management.mapper.BudgetItemTypeMapper;
+import org.springframework.stereotype.Service;
+
+/**
+ * 针对表【budget_item_type(预算科目类型)】的数据库操作Service实现
+ *
+ * @author pengshidun
+ * @since 2024-11-11
+ */
+@Service
+public class BudgetItemTypeServiceImpl extends ServiceImpl<BudgetItemTypeMapper, BudgetItemType> implements BudgetItemTypeService {
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,14 +10,14 @@ spring:
     password: password
     url: jdbc:mysql://localhost:3306/budget?characterEncoding=utf-8&serverTimezone=Asia/Shanghai
     driver-class-name: com.mysql.cj.jdbc.Driver
-  # redis缓存配置
-  redis:
-    host: localhost
-    port: 6379
-  # cache生命周期
-  cache:
-    redis:
-      time-to-live: 86400
+#  # redis缓存配置
+#  redis:
+#    host: localhost
+#    port: 6379
+#  # cache生命周期
+#  cache:
+#    redis:
+#      time-to-live: 86400
 
 # mybatisPlus配置
 mybatis-plus:
@@ -25,6 +25,14 @@ mybatis-plus:
     #在映射实体或者属性时，将数据库中表名和字段名中的下划线去掉，按照驼峰命名法映射
     map-underscore-to-camel-case: true
     log-impl: org.apache.ibatis.logging.stdout.StdOutImpl
+  global-config:
+    db-config:
+      # 逻辑删除字段名
+      logic-delete-field: isDeleted
+      # 逻辑删除字面值：未删除为0
+      logic-not-delete-value: 0
+      # 逻辑删除字面值：删除为1
+      logic-delete-value: 1
 
 # slf4j日志配置
 logging:

--- a/src/main/resources/mapper/BudgetItemTypeMapper.xml
+++ b/src/main/resources/mapper/BudgetItemTypeMapper.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="org.psd.budget_management.mapper.BudgetItemTypeMapper">
+
+    <resultMap id="BaseResultMap" type="org.psd.budget_management.entity.BudgetItemType">
+        <id property="id" column="id" jdbcType="INTEGER"/>
+        <result property="name" column="name" jdbcType="VARCHAR"/>
+        <result property="createTime" column="create_time" jdbcType="TIMESTAMP"/>
+        <result property="updateTime" column="update_time" jdbcType="TIMESTAMP"/>
+        <result property="isDeleted" column="is_deleted" jdbcType="INTEGER"/>
+    </resultMap>
+
+</mapper>

--- a/src/test/java/org/psd/budget_management/controller/BudgetItemTypeControllerTest.java
+++ b/src/test/java/org/psd/budget_management/controller/BudgetItemTypeControllerTest.java
@@ -1,0 +1,31 @@
+package org.psd.budget_management.controller;
+
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Test;
+import org.psd.budget_management.entity.BudgetItemType;
+import org.psd.budget_management.entity.Result;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+
+@Slf4j
+@SpringBootTest
+class BudgetItemTypeControllerTest {
+
+    @Autowired
+    private BudgetItemTypeController budgetItemTypeController;
+
+    @Test
+    void testInsert() {
+        BudgetItemType budgetItemType = new BudgetItemType();
+        budgetItemType.setName("营销费用");
+        System.out.println(budgetItemTypeController.insert(budgetItemType));
+    }
+
+    @Test
+    void testFindById() {
+        Integer id = 1;
+        Result result = budgetItemTypeController.findById(id);
+        log.info(result.toString());
+    }
+}


### PR DESCRIPTION
- 新增 BudgetItemType 实体类，用于预算科目类型的数据库操作
- 添加逻辑删除字段和自动填充功能
- 创建相关的 Service、Controller 和 Mapper 文件
- 更新应用配置，添加 MyBatis-Plus 全局配置 -移除 Redis 缓存配置