### PR TITLE
refactor(controller/service): 优化日志查询接口和方法命名

### DIFF
--- a/src/main/java/org/psd/budget_management/controller/BudgetCostLogController.java
+++ b/src/main/java/org/psd/budget_management/controller/BudgetCostLogController.java
@@ -58,7 +58,7 @@ public class BudgetCostLogController {
      */
     @GetMapping("/findByBudgetCostId/{budgetCostId}")
     public Result findByBudgetCostId(@PathVariable Integer budgetCostId) {
-        return new Result(200, "执行成功", this.budgetCostLogService.getById(budgetCostId));
+        return new Result(200, "执行成功", this.budgetCostLogService.findByBudgetCostId(budgetCostId));
     }
 
     /**

--- a/src/main/java/org/psd/budget_management/controller/BudgetItemLogController.java
+++ b/src/main/java/org/psd/budget_management/controller/BudgetItemLogController.java
@@ -58,7 +58,7 @@ public class BudgetItemLogController {
      */
     @GetMapping("/findByBudgetItemId/{budgetItemId}")
     public Result findByBudgetItemId(@PathVariable Integer budgetItemId) {
-        return new Result(200, "执行成功", this.budgetItemLogService.getById(budgetItemId));
+        return new Result(200, "执行成功", this.budgetItemLogService.findByBudgetItemId(budgetItemId));
     }
 
     /**

--- a/src/main/java/org/psd/budget_management/service/BudgetCostLogService.java
+++ b/src/main/java/org/psd/budget_management/service/BudgetCostLogService.java
@@ -19,5 +19,5 @@ public interface BudgetCostLogService extends IService<BudgetCostLog> {
      * @param budgetCostId 预算科目id
      * @return 返回该预算科目的所有日志
      */
-    public List<BudgetCostLog> findByBudgetCostId(Integer budgetCostId);
+    List<BudgetCostLog> findByBudgetCostId(Integer budgetCostId);
 }

--- a/src/main/java/org/psd/budget_management/service/BudgetItemLogService.java
+++ b/src/main/java/org/psd/budget_management/service/BudgetItemLogService.java
@@ -19,5 +19,5 @@ public interface BudgetItemLogService extends IService<BudgetItemLog> {
      * @param budgetItemId 预算科目id
      * @return 返回该预算科目的所有日志
      */
-    public List<BudgetItemLog> findByBudgetItemId(Integer budgetItemId);
+    List<BudgetItemLog> findByBudgetItemId(Integer budgetItemId);
 }


### PR DESCRIPTION
- 将 BudgetCostLogController 中的 getById 方法重命名为 findByBudgetCostId
- 将 BudgetItemLogController 中的 getById 方法重命名为 findByBudgetItemId
- 移除 BudgetCostLogService 和 BudgetItemLogService接口中的方法名前缀 public